### PR TITLE
fix: groupの数が多くなっても画面が崩れないように修正した

### DIFF
--- a/lib/UI/component/home/group_dropdown.dart
+++ b/lib/UI/component/home/group_dropdown.dart
@@ -23,6 +23,7 @@ class GroupDropdown extends StatelessWidget {
       child: DropdownButtonHideUnderline(
         child: DropdownButton<String>(
           isExpanded: true,
+          menuMaxHeight: 300,
           value: selectedGroupId,
           hint: const Text("選択してください"),
           items: [
@@ -38,7 +39,10 @@ class GroupDropdown extends StatelessWidget {
                 value: group['groupId'],
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
-                  child: Text(group['groupName'] ?? '名前なし'),
+                  child: Text(
+                    group['groupName'] ?? '名前なし',
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
               );
             }).toList(),


### PR DESCRIPTION
groupdropdownをスライドできるようにした


https://github.com/user-attachments/assets/8a86e833-cd9d-4eb0-8d7c-d7e3d936332d

